### PR TITLE
Fix replays in monthly folders not being detected

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ console.log(`Listening for game at: ${listenPath}`);
 
 const watcher = chokidar.watch(listenPath, {
   ignored: "!*.slp", // TODO: This doesn't work. Use regex?
-  depth: 0,
+  depth: 1, // needs to be at least 1 if saving replays to monthly folders
   persistent: true,
   usePolling: true,
   ignoreInitial: true,


### PR DESCRIPTION
If you use the Slippi replay option for saving monthly folders (Slippi -> General Settings -> Replays -> Root SLP Directory) then replays will be in subfolders that require a depth of at least 0 to be detected.

Example Slippi folder layout with monthly folders enabled:
```
Slippi
├───2024-08
│       Game_20240814T211209.slp
│       Game_20240814T212343.slp
│       Game_20240814T212648.slp
│
├───2024-09
│       Game_20240901T215718.slp
│       Game_20240901T220055.slp
│       Game_20240901T220448.slp
│
└───2024-10
        Game_20241001T221226.slp
        Game_20241001T221238.slp
        Game_20241001T221523.slp
```

If there is some performance impact if a user has thousands and thousands of games, then that can be mitigated by detecting just the current monthly folder. But this at least fixes the issue for now.

Slippi 2.11.6
Build 20240413
Windows 11